### PR TITLE
Improve spanish strings

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -22,49 +22,49 @@
 
     <!-- Error messages -->
     <string name="connection_error">Error de conexión</string>
-    <string name="json_error">Error al recuperar datos</string>
+    <string name="json_error">Error al obtener datos</string>
 
     <!-- Actions -->
-    <string name="action_settings">Ajustes </string>
+    <string name="action_settings">Ajustes</string>
     <string name="action_refresh">Refrescar</string>
     <string name="action_map">Mapa</string>
     <string name="action_directions">Rutas</string>
-    <string name="action_favorite">Favoritas</string>
+    <string name="action_favorite">Favoritos</string>
     <string name="action_my_location">Mi ubicación</string>
     <string name="action_search">Buscar</string>
 
     <!-- Activities titles -->
-    <string name="title_activity_stations_list">Estaciónes</string>
+    <string name="title_activity_stations_list">Estaciones</string>
     <string name="title_activity_station">Estación</string>
-    <string name="title_activity_networks_list">Seleccione Red Ciclo</string>
+    <string name="title_activity_networks_list">Seleccionar una red</string>
     <string name="title_activity_map">Mapa</string>
 
     <!-- Welcome dialog -->
     <string name="welcome_dialog_message">
-        Antes de empezar, elija una red de bicicletas en la Configuración
+        Antes de empezar, elija una red de bicicletas de la lista
     </string>
     <string name="welcome_dialog_ok">OK</string>
     <string name="welcome_dialog_cancel">Cancelar</string>
     <string name="welcome_dialog_title">Bienvenido</string>
 
     <!-- Map -->
-    <string name="location_not_found">Ubicación no encontrado</string>
-    <string name="network_selected">seleccionado</string>
-    <string name="bike_network_downloading">Por favor Espere mientras la red de bicicletas está siendo descargado</string>
+    <string name="location_not_found">Ubicación no encontrada</string>
+    <string name="network_selected">seleccionada</string>
+    <string name="bike_network_downloading">Por favor espere mientras la red de bicicletas está siendo descargada</string>
 
     <!-- Various -->
-    <string name="free_bikes">Bicicletas libras:\u00A0</string>
-    <string name="empty_slots">Las ranuras vacías:\u00A0</string>
+    <string name="free_bikes">Bicicletas:\u00A0</string>
+    <string name="empty_slots">Espacios:\u00A0</string>
     <string name="all_stations">Todas las estaciones</string>
-    <string name="favorite_stations">Favoritas</string>
-    <string name="station_added_to_favorites">Estación añadido a favoritas</string>
-    <string name="stations_removed_from_favorites">Estación retirado de favoritas</string>
-    <string name="no_nav_application">Usted no tiene ninguna aplicación de navegación instalado</string>
-    <string name="is_bonus_station">Bonus estación</string>
-    <string name="cards_accepted">Tarjetas aceptadas</string>
+    <string name="favorite_stations">Favoritos</string>
+    <string name="station_added_to_favorites">Estación añadida a favoritos</string>
+    <string name="stations_removed_from_favorites">Estación retirada de favoritos</string>
+    <string name="no_nav_application">Ninguna aplicación de navegación instalada</string>
+    <string name="is_bonus_station">Estación bonus</string>
+    <string name="cards_accepted">Acepta tarjeta</string>
     <string name="db_last_update">Última actualización: %1$s</string>
     <string name="db_last_update_never">nunca</string>
-    <string name="updated_just_now">Ahora</string>
+    <string name="updated_just_now">Ahora mismo</string>
     <plurals name="updated_minutes_ago">
         <item quantity="one">Hace %d minuto</item>
         <item quantity="other">Hace %d minutos</item>

--- a/app/src/main/res/values-es/strings_activity_settings.xml
+++ b/app/src/main/res/values-es/strings_activity_settings.xml
@@ -23,11 +23,11 @@
     <!-- Example General settings -->
     <string name="pref_header_general">General</string>
 
-    <string name="pref_title_bike_networks_list">Elige una red</string>
+    <string name="pref_title_bike_networks_list">Elija una red</string>
 
     <string name="pref_title_license">Licencia</string>
 
-    <string name="pref_title_about">Sobre</string>
+    <string name="pref_title_about">Acerca de</string>
     <string name="pref_title_website">Sitio Web</string>
     <string name="pref_title_source_code">Código fuente</string>
     <string name="pref_title_developers_website">Sitio web del desarrollador</string>
@@ -40,9 +40,9 @@
     <!-- Map layer -->
     <string name="pref_map_layer_title">Capa de mapa</string>
 
-    <string name="pref_title_strip_station_id">Ocultar el id de la estación</string>
+    <string name="pref_title_strip_station_id">Ocultar ID de la estación</string>
     <string name="pref_title_strip_station_id_summary">
-		Retire ID de nombre de la estación (sólo es útil para algunas redes)
+        Ocultar ID del nombre de la estación (útil para algunas redes)
     </string>
 
 </resources>


### PR DESCRIPTION
This branch improves spanish strings. Some corrections are typos, other are just a matter of preference. Tried the app to see what made sense.

For instance, Favourites (or bookmarks) is usually known in spanish as "Favoritos" (masucline or general), even though it refers to Favourite stations (estaciones favoritas (femenine)). Also impersonal forms are usually preferred over personal (You don't have vs [something] not found).

It's been so long since I do not use software in spanish that my technical jargon may be quite off.