### PR TITLE
Upgrade osmdroid

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ android {
 }
 
 dependencies {
-    compile 'org.osmdroid:osmdroid-android:5.6.4'
+    compile 'org.osmdroid:osmdroid-android:6.1.8'
     compile 'com.github.MKergall:osmbonuspack:6.3'
     compile 'com.android.support:support-v4:23.0.1'
 }

--- a/app/src/main/java/be/brunoparmentier/openbikesharing/app/activities/MapActivity.java
+++ b/app/src/main/java/be/brunoparmentier/openbikesharing/app/activities/MapActivity.java
@@ -39,6 +39,7 @@ import android.widget.Toast;
 
 import org.osmdroid.api.IMapController;
 import org.osmdroid.bonuspack.clustering.GridMarkerClusterer;
+import org.osmdroid.config.Configuration;
 import org.osmdroid.events.MapEventsReceiver;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.GeoPoint;
@@ -53,6 +54,7 @@ import org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay;
 import java.util.ArrayList;
 
 import be.brunoparmentier.openbikesharing.app.R;
+import be.brunoparmentier.openbikesharing.app.BuildConfig;
 import be.brunoparmentier.openbikesharing.app.db.StationsDataSource;
 import be.brunoparmentier.openbikesharing.app.models.Station;
 import be.brunoparmentier.openbikesharing.app.models.StationStatus;
@@ -96,6 +98,10 @@ public class MapActivity extends Activity implements MapEventsReceiver {
         stationsDataSource = new StationsDataSource(this);
         ArrayList<Station> stations = stationsDataSource.getStations();
 
+        final Context context = getApplicationContext();
+        Configuration.getInstance().load(context, PreferenceManager.getDefaultSharedPreferences(context));
+        Configuration.getInstance().setUserAgentValue(BuildConfig.APPLICATION_ID);
+
         map = (MapView) findViewById(R.id.mapView);
         stationMarkerInfoWindow = new StationMarkerInfoWindow(R.layout.bonuspack_bubble, map);
 
@@ -118,7 +124,7 @@ public class MapActivity extends Activity implements MapEventsReceiver {
 
         map.setMultiTouchControls(true);
         map.setBuiltInZoomControls(true);
-        map.setMinZoomLevel(3);
+        map.setMinZoomLevel(Double.valueOf(3));
 
         /* map tile source */
         String mapLayer = settings.getString(PREF_KEY_MAP_LAYER, "");
@@ -127,7 +133,7 @@ public class MapActivity extends Activity implements MapEventsReceiver {
                 map.setTileSource(TileSourceFactory.MAPNIK);
                 break;
             case MAP_LAYER_CYCLEMAP:
-                map.setTileSource(TileSourceFactory.CYCLEMAP);
+                map.setTileSource(TileSourceFactory.HIKEBIKEMAP);
                 break;
             case MAP_LAYER_OSMPUBLICTRANSPORT:
                 map.setTileSource(TileSourceFactory.PUBLIC_TRANSPORT);

--- a/app/src/main/java/be/brunoparmentier/openbikesharing/app/activities/StationActivity.java
+++ b/app/src/main/java/be/brunoparmentier/openbikesharing/app/activities/StationActivity.java
@@ -19,6 +19,7 @@ package be.brunoparmentier.openbikesharing.app.activities;
 
 import android.app.Activity;
 import android.appwidget.AppWidgetManager;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -36,6 +37,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import org.osmdroid.api.IMapController;
+import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
@@ -48,6 +50,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import be.brunoparmentier.openbikesharing.app.R;
+import be.brunoparmentier.openbikesharing.app.BuildConfig;
 import be.brunoparmentier.openbikesharing.app.db.StationsDataSource;
 import be.brunoparmentier.openbikesharing.app.models.Station;
 import be.brunoparmentier.openbikesharing.app.models.StationStatus;
@@ -79,6 +82,10 @@ public class StationActivity extends Activity {
 
         station = (Station) getIntent().getSerializableExtra(KEY_STATION);
 
+        final Context context = getApplicationContext();
+        Configuration.getInstance().load(context, PreferenceManager.getDefaultSharedPreferences(context));
+        Configuration.getInstance().setUserAgentValue(BuildConfig.APPLICATION_ID);
+
         map = (MapView) findViewById(R.id.mapView);
         final GeoPoint stationLocation = new GeoPoint((int) (station.getLatitude() * 1000000),
                 (int) (station.getLongitude() * 1000000));
@@ -93,7 +100,7 @@ public class StationActivity extends Activity {
                 map.setTileSource(TileSourceFactory.MAPNIK);
                 break;
             case MAP_LAYER_CYCLEMAP:
-                map.setTileSource(TileSourceFactory.CYCLEMAP);
+                map.setTileSource(TileSourceFactory.HIKEBIKEMAP);
                 break;
             case MAP_LAYER_OSMPUBLICTRANSPORT:
                 map.setTileSource(TileSourceFactory.PUBLIC_TRANSPORT);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,7 +121,7 @@
     <string name="pref_title_version">Version</string>
     <string name="pref_map_layer_title">Map layer</string>
     <string name="pref_map_layer_mapnik" translatable="false">Mapnik</string>
-    <string name="pref_map_layer_cyclemap" translatable="false">OpenCycleMap</string>
+    <string name="pref_map_layer_cyclemap" translatable="false">Hike &amp; Bike Map</string>
     <string name="pref_map_layer_osmpublictransport" translatable="false">OSMPublicTransport</string>
     <string name="pref_title_strip_station_id">Strip station ID</string>
     <string name="pref_title_strip_station_id_summary">


### PR DESCRIPTION
Hello.

It seems that Mapnik tiles is suffering download errors on recent Android versions (due to limitations raised by the OpenStreetMap administrators).
For example an Android 10 device face this issue (whereas Android 5 don't have it).

This PR do the following :
  - satisfy the new OSM requirements in order to solve #51
  - get osmdroid up to date
  - solves #34 as side effect (new osmdroid improves zoom quality).

Changes have been tested on Android 10 : working ; Android 5 is still working.